### PR TITLE
fix characters parsing issue with `urllib` decode on word input

### DIFF
--- a/src/urban.py
+++ b/src/urban.py
@@ -4,12 +4,13 @@
 # License: MIT
 
 import sys
+import urllib.parse
 
 from bs4 import BeautifulSoup, ResultSet, Tag
 import bs4
 import colorama
-import requests
 from loguru import logger
+import requests
 from requests.status_codes import _codes  # pyright: ignore
 from rich import print as rich_print
 
@@ -41,7 +42,27 @@ def join_words() -> str:
         except IndexError:
             rich_print("You need to specify a word. Example: urban drip")
             raise SystemExit
-    return word
+    decoded_word = parse_url_chars(word)
+    return decoded_word.strip()
+
+def parse_url_chars(words: str) -> str:
+    """Parse any weird url chars into readable text.
+
+    Raises:
+        TypeError: if `words` is not a string.
+
+    Parameters:
+        words: one string of words, that assumedly have url characters in them.
+
+    Returns:
+        Words with the url chars as readable text.
+    """
+
+    if not isinstance(words, str):
+        raise TypeError("Words must be a string. It should preferrably contain url characters.")
+
+    decoded_string = urllib.parse.unquote(words)
+    return decoded_string
 
 def deinit_sys_exit(exit_code: int = 0) -> None:
     """Uninitialize colorama and exit with `exit_code`.

--- a/src/urban.py
+++ b/src/urban.py
@@ -42,8 +42,9 @@ def join_words() -> str:
         except IndexError:
             rich_print("You need to specify a word. Example: urban drip")
             raise SystemExit
+
     decoded_word = parse_url_chars(word)
-    return decoded_word.strip()
+    return decoded_word
 
 def parse_url_chars(words: str) -> str:
     """Parse any weird url chars into readable text.
@@ -62,7 +63,7 @@ def parse_url_chars(words: str) -> str:
         raise TypeError("Words must be a string. It should preferrably contain url characters.")
 
     decoded_string = urllib.parse.unquote(words)
-    return decoded_string
+    return decoded_string.strip()
 
 def deinit_sys_exit(exit_code: int = 0) -> None:
     """Uninitialize colorama and exit with `exit_code`.

--- a/tests/test_unit_integration.py
+++ b/tests/test_unit_integration.py
@@ -14,8 +14,8 @@ from src.urban import (
     get_soup_object_from_word,
     insert_newline_for_break_tags,
     insert_space_after_chars,
-    join_words,
     main,
+    parse_url_chars,
     process_word,
 )
 
@@ -27,6 +27,17 @@ class TestUnitIntegration(unittest.TestCase):
         words = json.load(open("./tests/words.json", "r"))
         self.word = random.choice(words["words"])
         self.soup = get_soup_object_from_word(self.word)
+
+    def test_parse_url_chars(self):
+        """Test url chars are parsed into normal text"""
+
+        expected_result = "Hello world!"
+        self.assertEqual(parse_url_chars("   Hello%20world%21 "), expected_result)
+
+    def test_parse_raise(self):
+        """Test url chars parsing is raised typerror invalid str"""
+        with self.assertRaises(TypeError):
+            parse_url_chars(True)  # pyright: ignore
 
     def test_word_from_soup_raises_index_error(self):
         """Test that word from soup raises when a given value is missing"""


### PR DESCRIPTION
* Add `strip` on parsed word

* Add urllib decode function to parsed word

Authored-by: Joshua Rose <joshuarose099@gmail.com>