### PR TITLE
Fix punctuation spacing for backticks

### DIFF
--- a/urban/urban_utils.py
+++ b/urban/urban_utils.py
@@ -106,6 +106,14 @@ def remove_punctuation_spacing(text: str):
                         chars.pop(char)
                     case " ":
                         chars.pop(char)
+                    case "`":
+                        chars.pop(char)
+                    case "~":
+                        chars.pop(char)
+                    case "\\":
+                        chars.pop(char)
+                    case "/":
+                        chars.pop(char)
         except IndexError:
             break
 


### PR DESCRIPTION
* fix punctuation spacing for backticks

* Adds additional characters for 'just in case' situations ;)

Issue: #71

Authored-by: Joshua Rose <joshuarose099@gmail.com>